### PR TITLE
Recommend using absolute paths with cli commands

### DIFF
--- a/developer_resources/known_issues.md
+++ b/developer_resources/known_issues.md
@@ -9,9 +9,10 @@ nav_order: 3
 
 ### Version 0.2.0
 
-1.	New example project files: The URBANopt SDK version 0.2.0 release comes with new files for the example project (new mappers and a new base_workflow.osw file).  For compatibility purposes and to use all new features, you may want to update any existing projects with these new files.  The example project can be installed via the CLI with the following command:  
+1.	New example project files: The URBANopt SDK version 0.2.0 release comes with new files for the example project (new mappers and a new base_workflow.osw file).  For compatibility purposes and to use all new features, you may want to update any existing projects with these new files.  The example project can be installed via the CLI with the following command:
+
 ```bash
-	uo -p <PROJECT DIR> 
+	uo -p <path/to/PROJECT DIR> 
 ```
 
 1.	Project filepath length issue: Users (windows users especially) may run into an error while running URBANopt.  The error will be encountered either when running ‘bundle install’ in the project directory or in the in.osw.log file of a specific feature simulation and will look like this:
@@ -23,3 +24,5 @@ This will occur during installation of either the openstudio-standards gem or th
  1. URBANopt CLI users may see 2 lines of warning regarding `DEVELOPER_NREL_KEY`. This does not affect operation in any way. A future patch will remove the warning.
 
  1. Some users may experience issues with running the CLI from within the project directory. Try moving to a higher directory and using absolute paths to the feature_file (-f) and scenario CSV (-s).
+
+ 1. Many warnings get printed to the terminal when calling the URBANopt CLI from inside your project directory. The work-around to avoid these warnings is to move outside the project directory and use absolute paths when calling URBANopt commands. A hypothetical example: `uo -r -s ~/user/uo-project-directory/baseline_scenario.csv -f ~/user/uo-project-directory/example_project.json`

--- a/usage/example.md
+++ b/usage/example.md
@@ -16,7 +16,7 @@ The <u>hypothetical</u> example project design and building typologies are shown
 The example project can be installed via the Command Line Interface with the following command. For more information, visit the [Running a Project](run_project.md) page.
 
 ```terminal
-uo -p <PROJECT_DIRECTORY_NAME>
+uo -p <path/to/PROJECT_DIRECTORY_NAME>
 ```
 
 Working with the example project, you'll be able to:

--- a/usage/run_project.md
+++ b/usage/run_project.md
@@ -12,7 +12,7 @@ Once the CLI is installed, help is available by typing `uo -h` from the command 
 1. Create a project folder in your current directory using:
 
     ```terminal
-    uo -p <PROJECT_DIRECTORY_NAME>
+    uo -p <path/to/PROJECT_DIRECTORY_NAME>
     ```
 
     This creates a project folder containing the [example project](example.md), and downloads related weather files and detailed models to the appropriate folders.
@@ -20,7 +20,7 @@ Once the CLI is installed, help is available by typing `uo -h` from the command 
     Create an empty base project folder by using:
 
     ```terminal
-    uo -e -p <PROJECT_DIRECTORY_NAME>
+    uo -e -p <path/to/PROJECT_DIRECTORY_NAME>
     ```
     
     This creates project folder without an example FeatureFile and an empty weather folder. You can
@@ -29,23 +29,23 @@ Once the CLI is installed, help is available by typing `uo -h` from the command 
     Overwrite an existing folder by using:
 
     ```terminal
-    uo -o -p <PROJECT_DIRECTORY_NAME>
+    uo -o -p <path/to/PROJECT_DIRECTORY_NAME>
     ```
 
     This deletes anything in the named folder and creates a fresh project directory. Can be combined with `-e` to overwrite a directory with a new empty URBANopt project directory.
 
 1. Put your [FeatureFile](../overview/definitions.md) in the root of the folder you just created, or use the provided example.
-1. For all following commands you must be _inside the project directory_ you created in step 1.
+1. We recommend calling all URBANopt commands from _outside_ the project folder you created, using absolute paths to the relevant files.
 1. Create [ScenarioFiles](../overview/definitions.md) for all Features in the FeatureFile based off the example _mappers_ using:
 
     ```terminal
-    uo -m -f <FEATUREFILE>
+    uo -m -f <path/to/FEATUREFILE>
     ```
 
     Or create ScenarioFiles for a single [Feature](../overview/definitions.md) by specifying the Feature_ID in the arguments.
 
     ```terminal
-    uo -m -f <FEATUREFILE> -i <FEATURE_ID>
+    uo -m -f <path/to/FEATUREFILE> -i <FEATURE_ID>
     ```
 
     You may write your own mapper file for your own specific use case as needed, as well as make your own ScenarioFile by hand.  You may also make edits to the ScenarioFiles to mix and match mappers.
@@ -54,14 +54,15 @@ Once the CLI is installed, help is available by typing `uo -h` from the command 
    ScenarioFile by using:
 
     ```terminal
-    uo -r -f <FEATUREFILE> -s <SCENARIOFILE>
+    uo -r -f <path/to/FEATUREFILE> -s <path/to/SCENARIOFILE>
     ```
+
     Note that there is a *runner.conf* file automatically created in the project folder.  This file is used to configure the number of features to process in parallel as well as a few other parameters.  Make edits to this file prior to running the above command.
 
 1. Gather simulated features into a [Scenario](../overview/definitions.md) report by using:
 
     ```terminal
-    uo -g -t <TYPE> -f <FEATUREFILE> -s <SCENARIOFILE>
+    uo -g -t <TYPE> -f <path/to/FEATUREFILE> -s <path/to/SCENARIOFILE>
     ```
 
     Valid `TYPE`s are: `default`, `opendss`, `reopt-scenario`, `reopt-feature`
@@ -69,7 +70,7 @@ Once the CLI is installed, help is available by typing `uo -h` from the command 
 1. Delete an outdated [Scenario](../overview/definitions.md) run by using:
 
     ```terminal
-    uo -d -s <SCENARIOFILE>
+    uo -d -s <path/to/SCENARIOFILE>
     ```
 
 # Workflow Details


### PR DESCRIPTION
### Addresses #72 

### Pull Request Description

- Change usage instructions to show absolute paths with example cli commands
- Add item to known issues about warnings when using cli from inside project folder

### Checklist (Delete lines that don't apply)

- [x] Documentation has been modified appropriately
- [x] An ISSUE has been created that this is addressing. Issues will get added to the Change Log when the change_log.rb script is run
- [x] This branch is up-to-date with develop
