### PR TITLE
URBANopt CLI 0.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,8 +129,11 @@ venv.bak/
 .ropeproject
 
 # mkdocs documentation
-_site/
+_site
 doc_files/_site
+
+# Jekyll documentation (html translation of doc files)
+_site
 
 # mypy
 .mypy_cache/

--- a/.gitignore
+++ b/.gitignore
@@ -129,11 +129,8 @@ venv.bak/
 .ropeproject
 
 # mkdocs documentation
-_site
+_site/
 doc_files/_site
-
-# Jekyll documentation (html translation of doc files)
-_site
 
 # mypy
 .mypy_cache/

--- a/.gitignore
+++ b/.gitignore
@@ -132,8 +132,5 @@ venv.bak/
 _site
 doc_files/_site
 
-# Jekyll documentation (html translation of doc files)
-_site
-
 # mypy
 .mypy_cache/

--- a/developer_resources/compatibility_matrix.md
+++ b/developer_resources/compatibility_matrix.md
@@ -15,5 +15,4 @@ URBANopt depends on various other components to function. Ensure you have the pr
 |**0.1.1**       |0.1.0       |2.8       |2.2.4|Core Gem v0.1.0 <br/> GeoJSON Gem v0.1.0 <br/> Scenario Gem v0.1.1 <br/> REopt Gem v0.1.0|
 |**0.2.0**       |0.2.2       |2.9       |2.2.4|Core Gem v0.2.0 <br/> GeoJSON Gem v0.2.0 <br/> Scenario Gem v0.2.0 <br/> REopt Gem v0.2.0 <br/> DiTTo Reader v0.1.1|
 |**0.2.1**       |0.2.3       |2.9       |2.2.4|Core Gem v0.2.0 <br/> GeoJSON Gem v0.2.0 <br/> Scenario Gem v0.2.0 <br/> REopt Gem v0.2.1 <br/> DiTTo Reader v0.1.1|
-|**0.3.0**       |0.3.0       |3.0       |2.5|Core Gem v0.3.0 <br/> GeoJSON Gem v0.3.0 <br/> Scenario Gem v0.3.0 <br/> REopt Gem v0.3.0 <br/> DiTTo Reader v0.1.1|
-|**0.3.1**       |0.3.1       |3.0.1-rc1       |2.5|Core Gem v0.3.0 <br/> GeoJSON Gem v0.3.0 <br/> Scenario Gem v0.3.0 <br/> REopt Gem v0.3.0 <br/> DiTTo Reader v0.1.1|
+|**0.3.1**       |0.3.1       |3.0       |2.5.x|Core Gem v0.3.0 <br/> GeoJSON Gem v0.3.0 <br/> Scenario Gem v0.3.0 <br/> REopt Gem v0.3.0 <br/> DiTTo Reader v0.1.1|

--- a/developer_resources/compatibility_matrix.md
+++ b/developer_resources/compatibility_matrix.md
@@ -15,3 +15,4 @@ URBANopt depends on various other components to function. Ensure you have the pr
 |**0.1.1**       |0.1.0       |2.8       |2.2.4|Core Gem v0.1.0 <br/> GeoJSON Gem v0.1.0 <br/> Scenario Gem v0.1.1 <br/> REopt Gem v0.1.0|
 |**0.2.0**       |0.2.2       |2.9       |2.2.4|Core Gem v0.2.0 <br/> GeoJSON Gem v0.2.0 <br/> Scenario Gem v0.2.0 <br/> REopt Gem v0.2.0 <br/> DiTTo Reader v0.1.1|
 |**0.2.1**       |0.2.3       |2.9       |2.2.4|Core Gem v0.2.0 <br/> GeoJSON Gem v0.2.0 <br/> Scenario Gem v0.2.0 <br/> REopt Gem v0.2.1 <br/> DiTTo Reader v0.1.1|
+|**0.2.2**       |0.3.0       |2.9       |2.2.4|Core Gem v0.2.0 <br/> GeoJSON Gem v0.2.0 <br/> Scenario Gem v0.2.0 <br/> REopt Gem v0.2.1 <br/> DiTTo Reader v0.1.1|

--- a/developer_resources/compatibility_matrix.md
+++ b/developer_resources/compatibility_matrix.md
@@ -15,4 +15,5 @@ URBANopt depends on various other components to function. Ensure you have the pr
 |**0.1.1**       |0.1.0       |2.8       |2.2.4|Core Gem v0.1.0 <br/> GeoJSON Gem v0.1.0 <br/> Scenario Gem v0.1.1 <br/> REopt Gem v0.1.0|
 |**0.2.0**       |0.2.2       |2.9       |2.2.4|Core Gem v0.2.0 <br/> GeoJSON Gem v0.2.0 <br/> Scenario Gem v0.2.0 <br/> REopt Gem v0.2.0 <br/> DiTTo Reader v0.1.1|
 |**0.2.1**       |0.2.3       |2.9       |2.2.4|Core Gem v0.2.0 <br/> GeoJSON Gem v0.2.0 <br/> Scenario Gem v0.2.0 <br/> REopt Gem v0.2.1 <br/> DiTTo Reader v0.1.1|
-|**0.2.2**       |0.3.0       |2.9       |2.2.4|Core Gem v0.2.0 <br/> GeoJSON Gem v0.2.0 <br/> Scenario Gem v0.2.0 <br/> REopt Gem v0.2.1 <br/> DiTTo Reader v0.1.1|
+|**0.3.0**       |0.3.0       |3.0       |2.5|Core Gem v0.3.0 <br/> GeoJSON Gem v0.3.0 <br/> Scenario Gem v0.3.0 <br/> REopt Gem v0.3.0 <br/> DiTTo Reader v0.1.1|
+|**0.3.1**       |0.3.1       |3.0.1-rc1       |2.5|Core Gem v0.3.0 <br/> GeoJSON Gem v0.3.0 <br/> Scenario Gem v0.3.0 <br/> REopt Gem v0.3.0 <br/> DiTTo Reader v0.1.1|

--- a/developer_resources/known_issues.md
+++ b/developer_resources/known_issues.md
@@ -21,8 +21,8 @@ This will occur during installation of either the openstudio-standards gem or th
 
 1.	Walk-in refrigeration modeling: The "create_typical_building_from_model" measure in the model articulation gem that supports OpenStudio 2.9.1 adds in capability for modeling walk-in refrigeration to a select number of space types. However, this functionality requires discrete space types to be modeled, and not a whole building or whole story blended space types. As a result, when using the default URBANopt workflow that models a blended space type based on the GeoJSON footprints, the new functionality will not be enabled. If a workflow using the GeoJSON floor area and number of floors is used with the create_bar_from_building_type_ratios measure, then walk-in refrigeration can be added in URBANopt using this version of the model articulation gem.
 
- 1. URBANopt CLI users may see 2 lines of warning regarding `DEVELOPER_NREL_KEY`. This does not affect operation in any way. A future patch will remove the warning.
+1. URBANopt CLI users may see 2 lines of warning regarding `DEVELOPER_NREL_KEY`. This does not affect operation in any way. A future patch will remove the warning.
 
- 1. Some users may experience issues with running the CLI from within the project directory. Try moving to a higher directory and using absolute paths to the feature_file (-f) and scenario CSV (-s).
+1. Some users may experience issues with running the CLI from within the project directory. Try moving to a higher directory and using absolute or relative paths to the feature_file (-f) and scenario CSV (-s).
 
- 1. Many warnings get printed to the terminal when calling the URBANopt CLI from inside your project directory. The work-around to avoid these warnings is to move outside the project directory and use absolute paths when calling URBANopt commands. A hypothetical example: `uo run -s ~/user/uo-project-directory/baseline_scenario.csv -f ~/user/uo-project-directory/example_project.json`
+1. Many warnings get printed to the terminal when calling the URBANopt CLI from inside your project directory. The work-around to avoid these warnings is to move outside the project directory and use absolute or relative paths when calling URBANopt commands. A hypothetical example: `uo run -s ~/user/uo-project-directory/baseline_scenario.csv -f ~/user/uo-project-directory/example_project.json`

--- a/developer_resources/known_issues.md
+++ b/developer_resources/known_issues.md
@@ -12,7 +12,7 @@ nav_order: 3
 1.	New example project files: The URBANopt SDK version 0.2.0 release comes with new files for the example project (new mappers and a new base_workflow.osw file).  For compatibility purposes and to use all new features, you may want to update any existing projects with these new files.  The example project can be installed via the CLI with the following command:
 
 ```bash
-	uo -p <path/to/PROJECT DIR> 
+	uo create --project-folder <path/to/PROJECT DIR> 
 ```
 
 1.	Project filepath length issue: Users (windows users especially) may run into an error while running URBANopt.  The error will be encountered either when running ‘bundle install’ in the project directory or in the in.osw.log file of a specific feature simulation and will look like this:

--- a/developer_resources/known_issues.md
+++ b/developer_resources/known_issues.md
@@ -25,4 +25,4 @@ This will occur during installation of either the openstudio-standards gem or th
 
  1. Some users may experience issues with running the CLI from within the project directory. Try moving to a higher directory and using absolute paths to the feature_file (-f) and scenario CSV (-s).
 
- 1. Many warnings get printed to the terminal when calling the URBANopt CLI from inside your project directory. The work-around to avoid these warnings is to move outside the project directory and use absolute paths when calling URBANopt commands. A hypothetical example: `uo -r -s ~/user/uo-project-directory/baseline_scenario.csv -f ~/user/uo-project-directory/example_project.json`
+ 1. Many warnings get printed to the terminal when calling the URBANopt CLI from inside your project directory. The work-around to avoid these warnings is to move outside the project directory and use absolute paths when calling URBANopt commands. A hypothetical example: `uo run -s ~/user/uo-project-directory/baseline_scenario.csv -f ~/user/uo-project-directory/example_project.json`

--- a/installation/linux.md
+++ b/installation/linux.md
@@ -11,25 +11,25 @@ nav_order: 3
 
 **_Linux installation has not been tested exhaustively. Please submit a bug report via the Github issue page if you run into installation errors_**
 
-1. Install Ruby 2.2.4.  We recommend using `rbenv` to manage and install [Ruby 2.2.4](https://github.com/rbenv/rbenv#installation)  
- **Note**: URBANopt will update to Ruby 2.5 when OpenStudio 3.0 is released
- 1. Install Bundler version 1.17:
+1. Install Ruby 2.5 (anything in the 2.5.x range will work).  We recommend using `rbenv` to manage and install [Ruby 2.5](https://github.com/rbenv/rbenv#installation)  
+ 
+ 1. Install Bundler version 2.1:
 
 	```terminal
-	gem install bundler -v 1.17
+	gem install bundler -v 2.1
 	```
-1. Install [OpenStudio 2.9.1](https://github.com/NREL/OpenStudio/releases/tag/v2.9.1)  
+1. Install [OpenStudio 3.0](https://github.com/NREL/OpenStudio/releases/tag/v3.0.0)  
 1. Manually install [libpng12](https://www.linuxuprising.com/2018/05/fix-libpng12-0-missing-in-ubuntu-1804.html)  
 If you get gdbm libs errors like the following, you need to create symlinks to the appropriate version (`libgdbm.so.5` and `libgdbm_compat.so.4`):
 
 	```terminal
-	/usr/local/openstudio-2.9.1/bin/openstudio: error while loading shared libraries: libgdbm.so.3: cannot open shared object file: No such file or directory
+	/usr/local/openstudio-3.0.0/bin/openstudio: error while loading shared libraries: libgdbm.so.3: cannot open shared object file: No such file or directory
 	```
 
 	or:
 
 	```terminal
-	/usr/local/openstudio-2.9.1/bin/openstudio: error while loading shared libraries: libgdbm_compat.so.3: cannot open shared object file: No such file or directory
+	/usr/local/openstudio-3.0.0/bin/openstudio: error while loading shared libraries: libgdbm_compat.so.3: cannot open shared object file: No such file or directory
 	```
 
 

--- a/installation/linux.md
+++ b/installation/linux.md
@@ -24,7 +24,7 @@ nav_order: 3
 	```terminal
 	gem install bundler -v 2.1
 	```
-1. Install [OpenStudio 3.0.1](https://github.com/NREL/OpenStudio/releases/tag/v3.0.1) \
+1. Install [OpenStudio 3.0.0](https://github.com/NREL/OpenStudio/releases/tag/v3.0.0) \
 	OpenStudio is designed to be used on Ubuntu 18.04. For other Ubuntu versions, see the [troubleshooting](troubleshooting.md) page.
 
 1. Add the `RUBYLIB` environment variable path pointing to OpenStudio Ruby location by pasting the following line into your `.bash_profile`, `.zshenv` or similar file: 

--- a/installation/linux.md
+++ b/installation/linux.md
@@ -9,7 +9,7 @@ nav_order: 3
 
 ## Dependencies
 
-**_Linux installation has not been tested exhaustively. Please submit an issue if you run into installation errors_**
+**_Linux installation has not been tested exhaustively. Please submit a bug report via the Github issue page if you run into installation errors_**
 
 1. Install Ruby 2.2.4.  We recommend using `rbenv` to manage and install [Ruby 2.2.4](https://github.com/rbenv/rbenv#installation)  
  **Note**: URBANopt will update to Ruby 2.5 when OpenStudio 3.0 is released
@@ -52,7 +52,7 @@ If you get gdbm libs errors like the following, you need to create symlinks to t
 1. View available CLI commands with:
 
     ```terminal
-    uo -h
+    uo --help
     ```
 
 1. For detailed instructions, see our [example instructions](../usage/run_project.md)

--- a/installation/linux.md
+++ b/installation/linux.md
@@ -11,27 +11,21 @@ nav_order: 3
 
 **_Linux installation has not been tested exhaustively. Please submit a bug report via the Github issue page if you run into installation errors_**
 
-1. Install Ruby 2.5 (anything in the 2.5.x range will work).  We recommend using `rbenv` to manage and install [Ruby 2.5](https://github.com/rbenv/rbenv#installation)  
+1. Install Ruby 2.5 (anything in the 2.5.x range will work).  We recommend using [rbenv](https://github.com/rbenv/rbenv#installation) to manage and install [Ruby 2.5](https://github.com/rbenv/rbenv#installing-ruby-versions)
+    - Install rbenv on your system
+    - Install your desired Ruby version
+    - Do not forget the `rbenv init` step of rbenv installation
+    - Once installed, you may check which versions of Ruby have been installed and which one is active with: `rbenv versions`
+    - Set your current directory to use Ruby 2.5.x with: `rbenv local 2.5.x`
+    - Full documentation for rbenv can be found at the [rbenv github site](https://github.com/rbenv/rbenv#command-reference)
  
- 1. Install Bundler version 2.1:
+1. Install Bundler version 2.1:
 
 	```terminal
 	gem install bundler -v 2.1
 	```
-1. Install [OpenStudio 3.0](https://github.com/NREL/OpenStudio/releases/tag/v3.0.0)  
-1. Manually install [libpng12](https://www.linuxuprising.com/2018/05/fix-libpng12-0-missing-in-ubuntu-1804.html)  
-If you get gdbm libs errors like the following, you need to create symlinks to the appropriate version (`libgdbm.so.5` and `libgdbm_compat.so.4`):
-
-	```terminal
-	/usr/local/openstudio-3.0.0/bin/openstudio: error while loading shared libraries: libgdbm.so.3: cannot open shared object file: No such file or directory
-	```
-
-	or:
-
-	```terminal
-	/usr/local/openstudio-3.0.0/bin/openstudio: error while loading shared libraries: libgdbm_compat.so.3: cannot open shared object file: No such file or directory
-	```
-
+1. Install [OpenStudio 3.0.1](https://github.com/NREL/OpenStudio/releases/tag/v3.0.1) \
+	OpenStudio is designed to be used on Ubuntu 18.04. For other Ubuntu versions, see the [troubleshooting](troubleshooting.md) page.
 
 1. Add the `RUBYLIB` environment variable path pointing to OpenStudio Ruby location by pasting the following line into your `.bash_profile`, `.zshenv` or similar file: 
 

--- a/installation/mac.md
+++ b/installation/mac.md
@@ -23,7 +23,7 @@ nav_order: 1
 	gem install bundler -v 2.1
 	```
 
-1. Install [OpenStudio 3.0](https://github.com/NREL/OpenStudio/releases/tag/v3.0.0)  
+1. Install [OpenStudio 3.0.1](https://github.com/NREL/OpenStudio/releases/tag/v3.0.1)  
 1. Add the `RUBYLIB` path as an "environment variable", pointing to the OpenStudio Ruby location you just installed.  You can use a text editor such as TextEdit, Sublime Text, vi or nano to open `.bash_profile` (or `.zshenv` if using zsh, the default since MacOS 10.15 Catalina).  The following is an example using nano:
 
     1. Type the following in the terminal: `nano ~/.bash_profile` (or `nano ~/.zshenv`)

--- a/installation/mac.md
+++ b/installation/mac.md
@@ -17,7 +17,6 @@ nav_order: 1
     - Set your current directory to use Ruby 2.5.x with: `rbenv local 2.5.x`
     - Full documentation for rbenv can be found at the [rbenv github site](https://github.com/rbenv/rbenv#command-reference)
 
-
 1. Install Bundler version 2.1:
 
 	```terminal

--- a/installation/mac.md
+++ b/installation/mac.md
@@ -23,7 +23,7 @@ nav_order: 1
 	gem install bundler -v 2.1
 	```
 
-1. Install [OpenStudio 3.0.1](https://github.com/NREL/OpenStudio/releases/tag/v3.0.1)  
+1. Install [OpenStudio 3.0.0](https://github.com/NREL/OpenStudio/releases/tag/v3.0.0)  
 1. Add the `RUBYLIB` path as an "environment variable", pointing to the OpenStudio Ruby location you just installed.  You can use a text editor such as TextEdit, Sublime Text, vi or nano to open `.bash_profile` (or `.zshenv` if using zsh, the default since MacOS 10.15 Catalina).  The following is an example using nano:
 
     1. Type the following in the terminal: `nano ~/.bash_profile` (or `nano ~/.zshenv`)

--- a/installation/mac.md
+++ b/installation/mac.md
@@ -43,7 +43,7 @@ nav_order: 1
 1. View available CLI commands with:
 
     ```terminal
-    uo -h
+    uo --help
     ```
 
 1. For detailed instructions, see our [example instructions](../usage/run_project.md)

--- a/installation/mac.md
+++ b/installation/mac.md
@@ -9,23 +9,22 @@ nav_order: 1
 
 ## Dependencies
 
-1. Install Ruby 2.2.4.  We recommend using [rbenv](https://github.com/rbenv/rbenv#installation) to manage and install [Ruby 2.2.4](https://github.com/rbenv/rbenv#installing-ruby-versions)
+1. Install Ruby 2.5 (anything in the 2.5.x range will work).  We recommend using [rbenv](https://github.com/rbenv/rbenv#installation) to manage and install [Ruby 2.5](https://github.com/rbenv/rbenv#installing-ruby-versions)
     - `brew install rbenv`
-    - `rbenv install 2.2.4`
+    - `rbenv install 2.5.x`
     - Do not forget the `rbenv init` step of rbenv installation
     - Once installed, you may check which versions of Ruby have been installed and which one is active with: `rbenv versions`
-    - Set your current directory to use Ruby 2.2.4 with: `rbenv local 2.2.4`
+    - Set your current directory to use Ruby 2.5.x with: `rbenv local 2.5.x`
     - Full documentation for rbenv can be found at the [rbenv github site](https://github.com/rbenv/rbenv#command-reference)
 
-    **Note**: URBANopt will update to a newer Ruby version when OpenStudio 3.0 is released
 
-1. Install Bundler version 1.17:
+1. Install Bundler version 2.1:
 
 	```terminal
-	gem install bundler -v 1.17
+	gem install bundler -v 2.1
 	```
 
-1. Install [OpenStudio 2.9.1](https://github.com/NREL/OpenStudio/releases/tag/v2.9.1)  
+1. Install [OpenStudio 3.0](https://github.com/NREL/OpenStudio/releases/tag/v3.0.0)  
 1. Add the `RUBYLIB` path as an "environment variable", pointing to the OpenStudio Ruby location you just installed.  You can use a text editor such as TextEdit, Sublime Text, vi or nano to open `.bash_profile` (or `.zshenv` if using zsh, the default since MacOS 10.15 Catalina).  The following is an example using nano:
 
     1. Type the following in the terminal: `nano ~/.bash_profile` (or `nano ~/.zshenv`)

--- a/installation/troubleshooting.md
+++ b/installation/troubleshooting.md
@@ -38,3 +38,18 @@ Edit the new `.gemrc` file to contain:
 ```terminal
 gem install bundler -v 2.1
 ```
+
+## Installing OpenStudio in Ubuntu < 18.04:
+
+Manually install [libpng12](https://www.linuxuprising.com/2018/05/fix-libpng12-0-missing-in-ubuntu-1804.html)
+- If you get gdbm libs errors like the following, you need to create symlinks to the appropriate version (`libgdbm.so.5` and `libgdbm_compat.so.4`):
+
+	```terminal
+	/usr/local/openstudio-3.0.0/bin/openstudio: error while loading shared libraries: libgdbm.so.3: cannot open shared object file: No such file or directory
+	```
+
+	or:
+
+	```terminal
+	/usr/local/openstudio-3.0.0/bin/openstudio: error while loading shared libraries: libgdbm_compat.so.3: cannot open shared object file: No such file or directory
+	```

--- a/installation/troubleshooting.md
+++ b/installation/troubleshooting.md
@@ -36,5 +36,5 @@ Edit the new `.gemrc` file to contain:
 - Now install **bundler**:
 
 ```terminal
-gem install bundler -v 1.17
+gem install bundler -v 2.1
 ```

--- a/installation/windows.md
+++ b/installation/windows.md
@@ -70,7 +70,7 @@ nav_order: 2
 1. View available CLI commands with:
 
     ```terminal
-    uo -h
+    uo --help
     ```
 
 1. For detailed instructions, see our [example instructions](../usage/run_project.md)

--- a/installation/windows.md
+++ b/installation/windows.md
@@ -25,7 +25,7 @@ nav_order: 2
 	gem install bundler -v 2.1
 	```
 
-1. Install [OpenStudio 3.0.1](https://github.com/NREL/OpenStudio/releases/tag/v3.0.1)  
+1. Install [OpenStudio 3.0.0](https://github.com/NREL/OpenStudio/releases/tag/v3.0.0)  
 1. Create file `C:\ruby-2.5.5-1-x64-mingw32\lib\ruby\site_ruby\openstudio.rb` and edit it to contain the path to your installed OpenStudio (where X.X.X is the OpenStudio version installed):
 
 	```ruby

--- a/installation/windows.md
+++ b/installation/windows.md
@@ -9,26 +9,25 @@ nav_order: 2
 
 ## Dependencies
 
-1. Install [Ruby 2.2.4 (x64)](https://dl.bintray.com/oneclick/rubyinstaller/rubyinstaller-2.2.4-x64.exe)  
-**Note**: URBANopt will update to a newer Ruby version when OpenStudio 3.0 is released
+1. Install [Ruby 2.5 (x64) with Devkit](https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-2.5.8-1/rubyinstaller-devkit-2.5.8-1-x86.exe)  
 
-1. Install Devkit using the [mingw64](https://dl.bintray.com/oneclick/rubyinstaller/DevKit-mingw64-64-4.7.2-20130224-1432-sfx.exe) installer  
+
 1. Include path to Ruby by adding the following to your environment variables path: 
 
-	`C:\Ruby22-x64\bin`
+	`C:\Ruby25-x64\bin`
 1. Create a new environment variable `HOME` and set the variable value to the following: 
 
 	`C:\Users\<user_name>`
 
 	Detailed instructions for [creating environment variables](https://helpdeskgeek.com/how-to/create-custom-environment-variables-in-windows/) can be found online.
-1. Install Bundler version 1.17:
+1. Install Bundler version 2.1:
 
 	```terminal
-	gem install bundler -v 1.17
+	gem install bundler -v 2.1
 	```
 
-1. Install [OpenStudio 2.9.1](https://github.com/NREL/OpenStudio/releases/tag/v2.9.1)  
-1. Create file `C:\ruby-2.2.4-x64-mingw32\lib\ruby\site_ruby\openstudio.rb` and edit it to contain the path to your installed OpenStudio (where X.X.X is the OpenStudio version installed):
+1. Install [OpenStudio 3.0](https://github.com/NREL/OpenStudio/releases/tag/v3.0.0)  
+1. Create file `C:\ruby-2.5.8-x64-mingw32\lib\ruby\site_ruby\openstudio.rb` and edit it to contain the path to your installed OpenStudio (where X.X.X is the OpenStudio version installed):
 
 	```ruby
 	require 'C:\openstudio-X.X.X\Ruby\openstudio.rb'
@@ -45,7 +44,7 @@ nav_order: 2
 	```terminal
 	OS:Version,
 	 {<long-uuid>},                          !- Handle
-	 2.8.1;                                  !- Version Identifier`
+	 3.0.0;                                  !- Version Identifier`
 	 ```
 
 <!-- 1. Install [Git](https://git-scm.com/) if not already installed. A list of [optional git

--- a/installation/windows.md
+++ b/installation/windows.md
@@ -9,8 +9,7 @@ nav_order: 2
 
 ## Dependencies
 
-1. Install [Ruby 2.5 (x64) with Devkit](https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-2.5.8-1/rubyinstaller-devkit-2.5.8-1-x86.exe)  
-
+1. Install [Ruby 2.5 (x64)](https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-2.5.5-1/rubyinstaller-2.5.5-1-x64.exe)  
 
 1. Include path to Ruby by adding the following to your environment variables path: 
 
@@ -27,7 +26,7 @@ nav_order: 2
 	```
 
 1. Install [OpenStudio 3.0](https://github.com/NREL/OpenStudio/releases/tag/v3.0.0)  
-1. Create file `C:\ruby-2.5.8-x64-mingw32\lib\ruby\site_ruby\openstudio.rb` and edit it to contain the path to your installed OpenStudio (where X.X.X is the OpenStudio version installed):
+1. Create file `C:\ruby-2.5.5-1-x64-mingw32\lib\ruby\site_ruby\openstudio.rb` and edit it to contain the path to your installed OpenStudio (where X.X.X is the OpenStudio version installed):
 
 	```ruby
 	require 'C:\openstudio-X.X.X\Ruby\openstudio.rb'

--- a/installation/windows.md
+++ b/installation/windows.md
@@ -25,7 +25,7 @@ nav_order: 2
 	gem install bundler -v 2.1
 	```
 
-1. Install [OpenStudio 3.0](https://github.com/NREL/OpenStudio/releases/tag/v3.0.0)  
+1. Install [OpenStudio 3.0.1](https://github.com/NREL/OpenStudio/releases/tag/v3.0.1)  
 1. Create file `C:\ruby-2.5.5-1-x64-mingw32\lib\ruby\site_ruby\openstudio.rb` and edit it to contain the path to your installed OpenStudio (where X.X.X is the OpenStudio version installed):
 
 	```ruby

--- a/reopt/reopt_post_processing.md
+++ b/reopt/reopt_post_processing.md
@@ -6,7 +6,7 @@ nav_order: 2
 ---
 ## Intro
 
-CLI commands are used to run and post-process each scenario. Onscreen help is always availabe with `uo -h`
+CLI commands are used to run and post-process each scenario. Onscreen help is always availabe with `uo --help`
 
 **REopt Lite** optimization happens during the post-processing of each scenario. Two types of REopt optimization are available: _scenario-level_, which optimizes for the entire district being simulated, and _feature-level_, which optimizes each building individually.
 
@@ -17,13 +17,13 @@ The `type` of reopt optimization is specified in the CLI call:
 This command allows you to post-process a ScenarioReport in aggregate. This is suitable for community-scale optimizations.
 
 ```terminal
-  uo -g -t reopt-scenario -s baseline_scenario.csv -f example_project.json  
+  uo process reopt-scenario --scenario baseline_scenario.csv --feature example_project.json  
 ```
 
 Alternatively, this command allows you to post-process a Scenario for each of its Feature Reports before aggregating into a summary in the Scenario Report. This runs REopt optimization on each building individually.
 
 ```terminal
-  uo -g -t reopt-feature -s baseline_scenario.csv -f example_project.json  
+  uo process reopt-feature --scenario baseline_scenario.csv --feature example_project.json  
 ```
 
 Depending on the `type` of optimization chosen, **REopt Lite** runs on a _**ScenarioReport**_ or _**FeatureReport**_. The resulting `distributed_generation` attributes (including system financial and sizing attributes) are updated as shown in an example below. 
@@ -84,7 +84,7 @@ Moreover, the following optimal dispatch fields are added to its `timeseries CSV
 
 **NOTE**: A REopt Lite solution may contain multiple PV systems. In this case the aggregate generation from all PV systems will be reported in the PV columns.
 
-The figure below describes the workflow that takes place on implementing the `run` and `gather` CLI commands.
+The figure below describes the workflow that takes place on implementing the `run` and `process` CLI commands.
 
 ![workflow_diagram](../doc_files/CLI_reopt.jpg)
 

--- a/usage/example.md
+++ b/usage/example.md
@@ -5,7 +5,7 @@ parent: Usage
 nav_order: 1
 ---
 
-You have access to a ***<u>hypothetical</u>*** URBANopt example project that was created to demonstrate various capabilities of the URBANopt SDK in version 0.2.0 (e.g. modeling of various building types and heights in one district). An actual location for the <u>hypothetical</u> project was needed to demonstrate geospatial aspects of the URBANopt SDK.
+You have access to a ***<u>hypothetical</u>*** URBANopt example project that was created to demonstrate various capabilities of the URBANopt SDK in version 0.3 (e.g. modeling of various building types and heights in one district). An actual location for the <u>hypothetical</u> project was needed to demonstrate geospatial aspects of the URBANopt SDK.
 
 The <u>hypothetical</u> example project’s location is within the boundary of an actual district project that is a participant in the U.S. Department of Energy Zero Energy District Accelerator. See “Western New York Manufacturing Zero Energy District” in [this NREL paper](https://www.nrel.gov/docs/fy18osti/71841.pdf) for a description of the actual project. The design in the <u>hypothetical</u> URBANopt example project has no relation to the designs and site requirements of the actual development project.
 

--- a/usage/example.md
+++ b/usage/example.md
@@ -16,7 +16,7 @@ The <u>hypothetical</u> example project design and building typologies are shown
 The example project can be installed via the Command Line Interface with the following command. For more information, visit the [Running a Project](run_project.md) page.
 
 ```terminal
-uo -p <path/to/PROJECT_DIRECTORY_NAME>
+uo create --project-folder <path/to/PROJECT_DIRECTORY_NAME>
 ```
 
 Working with the example project, you'll be able to:

--- a/usage/run_project.md
+++ b/usage/run_project.md
@@ -7,12 +7,12 @@ nav_order: 2
 
 To run URBANopt, first [install](../installation/installation.md) the project dependencies and the URBANopt Command Line Interface.
 
-Once the CLI is installed, help is available by typing `uo -h` from the command line.
+Once the CLI is installed, help is available by typing `uo --help` from the command line. Detailed help for each command can be found with `uo <command> --help`
 
 1. Create a project folder in your current directory using:
 
     ```terminal
-    uo -p <path/to/PROJECT_DIRECTORY_NAME>
+    uo create --project-folder <path/to/PROJECT_DIRECTORY_NAME>
     ```
 
     This creates a project folder containing the [example project](example.md), and downloads related weather files and detailed models to the appropriate folders.
@@ -20,7 +20,7 @@ Once the CLI is installed, help is available by typing `uo -h` from the command 
     Create an empty base project folder by using:
 
     ```terminal
-    uo -e -p <path/to/PROJECT_DIRECTORY_NAME>
+    uo create --empty --project-folder <path/to/PROJECT_DIRECTORY_NAME>
     ```
     
     This creates project folder without an example FeatureFile and an empty weather folder. You can
@@ -29,7 +29,7 @@ Once the CLI is installed, help is available by typing `uo -h` from the command 
     Overwrite an existing folder by using:
 
     ```terminal
-    uo -o -p <path/to/PROJECT_DIRECTORY_NAME>
+    uo create --overwrite --project-folder <path/to/PROJECT_DIRECTORY_NAME>
     ```
 
     This deletes anything in the named folder and creates a fresh project directory. Can be combined with `-e` to overwrite a directory with a new empty URBANopt project directory.
@@ -39,13 +39,19 @@ Once the CLI is installed, help is available by typing `uo -h` from the command 
 1. Create [ScenarioFiles](../overview/definitions.md) for all Features in the FeatureFile based off the example _mappers_ using:
 
     ```terminal
-    uo -m -f <path/to/FEATUREFILE>
+    uo create --scenario-file <path/to/FEATUREFILE>
     ```
 
-    Or create ScenarioFiles for a single [Feature](../overview/definitions.md) by specifying the Feature_ID in the arguments.
+    Or create a ScenarioFile for a single [Feature](../overview/definitions.md) by specifying the Feature_ID in the arguments.
 
     ```terminal
-    uo -m -f <path/to/FEATUREFILE> -i <FEATURE_ID>
+    uo create --scenario-file <path/to/FEATUREFILE> --single-feature <FEATURE_ID>
+    ```
+
+    Or create a ScenarioFile with additional REopt information to enable running and post-processing with REopt data.
+
+    ```terminal
+    uo create --reopt-scenario-file <path/to/EXISTING_SCENARIO_FILE>
     ```
 
     You may write your own mapper file for your own specific use case as needed, as well as make your own ScenarioFile by hand.  You may also make edits to the ScenarioFiles to mix and match mappers.
@@ -54,15 +60,21 @@ Once the CLI is installed, help is available by typing `uo -h` from the command 
    ScenarioFile by using:
 
     ```terminal
-    uo -r -f <path/to/FEATUREFILE> -s <path/to/SCENARIOFILE>
+    uo run --feature <path/to/FEATUREFILE> --scenario <path/to/SCENARIOFILE>
+    ```
+
+1. Simulate energy usage for a scenario with additional REopt capability. Run this simulation to enable REopt post-processing (see below for details).
+
+    ```terminal
+    uo run --reopt --feature <path/to/FEATUREFILE> --scenario <path/to/SCENARIOFILE>
     ```
 
     Note that there is a *runner.conf* file automatically created in the project folder.  This file is used to configure the number of features to process in parallel as well as a few other parameters.  Make edits to this file prior to running the above command.
 
-1. Gather simulated features into a [Scenario](../overview/definitions.md) report by using:
+1. Post-process simulated features into a [Scenario](../overview/definitions.md) report by using:
 
     ```terminal
-    uo -g -t <TYPE> -f <path/to/FEATUREFILE> -s <path/to/SCENARIOFILE>
+    uo process --<TYPE> --feature <path/to/FEATUREFILE> --scenario <path/to/SCENARIOFILE>
     ```
 
     Valid `TYPE`s are: `default`, `opendss`, `reopt-scenario`, `reopt-feature`
@@ -70,7 +82,7 @@ Once the CLI is installed, help is available by typing `uo -h` from the command 
 1. Delete an outdated [Scenario](../overview/definitions.md) run by using:
 
     ```terminal
-    uo -d -s <path/to/SCENARIOFILE>
+    uo delete --scenario <path/to/SCENARIOFILE>
     ```
 
 # Workflow Details

--- a/usage/run_project.md
+++ b/usage/run_project.md
@@ -35,7 +35,7 @@ Once the CLI is installed, help is available by typing `uo --help` from the comm
     This deletes anything in the named folder and creates a fresh project directory. Can be combined with `-e` to overwrite a directory with a new empty URBANopt project directory.
 
 1. Put your [FeatureFile](../overview/definitions.md) in the root of the folder you just created, or use the provided example.
-1. We recommend calling all URBANopt commands from _outside_ the project folder you created, using absolute paths to the relevant files.
+1. **We recommend calling all URBANopt commands from _outside_ the project folder you created, using relative or absolute paths to the relevant files.**
 1. Create [ScenarioFiles](../overview/definitions.md) for all Features in the FeatureFile based off the example _mappers_ using:
 
     ```terminal


### PR DESCRIPTION
### Addresses #78 

### Pull Request Description

We may not release CLI 0.3.0 until UO is upgraded to use OS 3.0. If that is true there will be additional changes to the CLI in 0.3.0, and these docs will need to be modified as well.

- Write docs for CLI 0.3.0
- Add row to compatibility matrix

### Checklist

- [x] Documentation has been modified appropriately
- [x] An ISSUE has been created that this is addressing. Issues will get added to the Change Log when the change_log.rb script is run
- [x] This branch is up-to-date with develop
