### PR TITLE
docs for renewable min/max in assumptions file

### DIFF
--- a/workflows/reopt/reopt_post_processing.md
+++ b/workflows/reopt/reopt_post_processing.md
@@ -28,7 +28,8 @@ In particular, you will want to make sure that the `urdb_label` in the assumptio
 Also note that the example `reopt/multiPV_assumptions.json` file contains an array of PV inputs to allow for the optimization of multiple PV systems at once.
 
 Lots of detail can be specified by customizing the REopt assumptions file. Some examples:
-- To simulate an off-grid scenario, inside the selected assumptions file change `off_grid_flag` to `true`.
+- To simulate an off-grid scenario: change `off_grid_flag` to `true`.
+- To set min/max renewable fraction of power in a district: change `renewable_electricity_min_pct` and/or `renewable_electricity_max_pct` to a value between 0-1.
 
 ### REopt Time Series Resolution
 


### PR DESCRIPTION
### Pull Request Description

Documents how to change min/max renewable fraction in the assumptions file, and reminds users of range of acceptable values

_Probable breaking change coming!_ The REopt team is likely to change the name of this variable to be `_fraction` instead of `_pct`. If/when that happens, we'll have to change our assumptions file for it to continue working.

### Checklist (Delete lines that don't apply)

- [x] Documentation has been modified appropriately
- [ ] An ISSUE has been created that this is addressing. Issues will get added to the Change Log when the change_log.rb script is run
- [ ] This branch is up-to-date with develop
