### PR TITLE
We only support Ruby 2.7.2 at this time

### DIFF
--- a/installation/linux.md
+++ b/installation/linux.md
@@ -31,12 +31,12 @@ e.g.:  ```/usr/local/urbanopt-cli-0.3.1/```
 
 **_Linux installation has not been tested exhaustively. Please submit a bug report via the [Github issue page](https://github.com/urbanopt/urbanopt-cli/issues) if you run into installation errors_**
 
-1. Install Ruby 2.7 (anything in the 2.7.x range will work).  We recommend using [rbenv](https://github.com/rbenv/rbenv#installation) to manage and install [Ruby 2.7](https://github.com/rbenv/rbenv#installing-ruby-versions)
+1. Install Ruby 2.7.2.  We recommend using [rbenv](https://github.com/rbenv/rbenv#installation) to manage and install [Ruby](https://github.com/rbenv/rbenv#installing-ruby-versions)
     - Install rbenv on your system
     - Install your desired Ruby version
     - Do not forget the `rbenv init` step of rbenv installation
     - Once installed, you may check which versions of Ruby have been installed and which one is active with: `rbenv versions`
-    - Set your current directory to use Ruby 2.7.x with: `rbenv local 2.7.x`
+    - Set your current directory to use Ruby 2.7.2 with: `rbenv local 2.7.2`
     - Full documentation for rbenv can be found at the [rbenv github site](https://github.com/rbenv/rbenv#command-reference)
 
 1. Install Bundler version 2.1:

--- a/installation/mac.md
+++ b/installation/mac.md
@@ -33,12 +33,12 @@ Follow the steps below or watch the [Mac Installer Video](https://urbanopt-tutor
 
 Follow the steps below or watch the [Mac Manual Installation Video](https://urbanopt-tutorial.s3.amazonaws.com/videos/04_Mac_Manual_Install.mp4).
 
-1. Install Ruby 2.7.2 (anything in the 2.7.x range will work).  We recommend using [rbenv](https://github.com/rbenv/rbenv#installation) to manage and install [Ruby 2.7](https://github.com/rbenv/rbenv#installing-ruby-versions)
+1. Install Ruby 2.7.2.  We recommend using [rbenv](https://github.com/rbenv/rbenv#installation) to manage and install [Ruby](https://github.com/rbenv/rbenv#installing-ruby-versions)
     - `brew install rbenv`
-    - `rbenv install 2.7.x`
+    - `rbenv install 2.7.2`
     - Do not forget the `rbenv init` step of rbenv installation
     - Once installed, you may check which versions of Ruby have been installed and which one is active with: `rbenv versions`
-    - Set your current directory to use Ruby 2.7.x with: `rbenv local 2.7.x`
+    - Set your current directory to use Ruby 2.7.2 with: `rbenv local 2.7.2`
     - Full documentation for rbenv can be found at the [rbenv github site](https://github.com/rbenv/rbenv#command-reference)
 
 1. Install Bundler version 2.1:


### PR DESCRIPTION
### Pull Request Description

One of the OpenStudio repos (I forget which! 😞 ) only supports Ruby 2.7.2, so our workflow breaks if using any other version of Ruby.

### Checklist
<!--Delete lines that don't apply-->

- [x] Documentation has been modified appropriately
- [x] This branch is up-to-date with develop
