### PR TITLE
Widen content & update dependency versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'http://rubygems.org'
 gem 'github-pages', group: :jekyll_plugins
-gem 'github_api', "~> 0.18.0"
+gem 'github_api', "~> 0.19.0"
 
-gem "just-the-docs", "0.4.1"
+gem "just-the-docs", "0.10.0"

--- a/assets/css/just-the-docs-default.scss
+++ b/assets/css/just-the-docs-default.scss
@@ -9,6 +9,7 @@
 
 @media (min-width: 50rem) {
   .main {
-    max-width: 1000px !important;
+      /* This controls the total available width of the content */
+    max-width: 1050px !important;
   }
 }


### PR DESCRIPTION
Supersedes #220 

### Pull Request Description

Since we're going to Ruby 3.2.2, I figured we could update the versions of our docs build software.

This also widens the content to take up more of the screen. The motivation is so the compatibility matrix doesn't need to be scrolled to view the entire thing.

### Checklist
<!--Delete lines that don't apply-->

- [ ] Documentation has been modified appropriately
- [ ] An ISSUE has been created that this is addressing. Issues will get added to the Change Log when the change_log.rb script is run
- [x] This branch is up-to-date with develop
